### PR TITLE
docs: use compose up instead of compose restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ are important to look at.
 4. Set your password by executing `docker compose exec nts nts_set_pwd` and
 entering it at the prompt.
 
-4. Restart the service using `docker compose restart` to apply your password.
+4. Restart the service using `docker compose up -d` to apply your password.
 
 ## Security
 


### PR DESCRIPTION
This updates the instructions in the README to use `docker compose up -d` instead of `docker compose restart` to restart the container after editing the password.