### PR TITLE
Disallow Option::unwrap and Result::unwrap using clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "nts"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+  "std::option::Option::unwrap",
+  "std::result::Result::unwrap",
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 disallowed-methods = [
-  "std::option::Option::unwrap",
-  "std::result::Result::unwrap",
+  { path = "std::option::Option::unwrap", reason = "refactor this code to handle the error correctly or explain why this is ok using Option::expect" },
+  { path = "std::result::Result::unwrap", reason = "refactor this code to handle the error correctly or explain why this is ok using Result::expect" },
 ]


### PR DESCRIPTION
This PR adds `Option::unwrap` and `Result::unwrap` to clippy's `disallowed-methods`. You should either correctly handle the error or use the respective `expect` methods to explain why this should be ok.