### PR TITLE
Treat notes that only contain the template as empty

### DIFF
--- a/crates/nts/src/lib.rs
+++ b/crates/nts/src/lib.rs
@@ -57,7 +57,7 @@ async fn new_note(
 ) -> (StatusCode, String) {
     let body = body.trim();
 
-    if body == state.0.template.trim() {
+    if body == state.0.template.trim() || body.is_empty() {
         return (StatusCode::OK, "note was empty".to_string());
     }
 

--- a/crates/nts/src/lib.rs
+++ b/crates/nts/src/lib.rs
@@ -57,7 +57,7 @@ async fn new_note(
 ) -> (StatusCode, String) {
     let body = body.trim();
 
-    if body.is_empty() {
+    if body == state.0.template.trim() {
         return (StatusCode::OK, "note was empty".to_string());
     }
 

--- a/crates/nts/src/state.rs
+++ b/crates/nts/src/state.rs
@@ -14,8 +14,6 @@ pub struct State {
 
     pub password_hash: Option<String>,
 
-    pub external_url: String,
-
     pub template: String,
 
     pub new_script: String,
@@ -51,7 +49,6 @@ impl State {
         Ok(Self {
             data_dir,
             password_hash,
-            external_url,
             template,
             new_script,
             get_script,


### PR DESCRIPTION
Previously, if a template was set, no note would ever be treated as empty. Now, a note is treated empty if it is equal to the template or if it is completely empty.