### PR TITLE
Build `nts_set_pwd` using nix flakes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
 resolver = "2"
 members = ["crates/nts", "crates/nts_set_pwd"]
-# default-members = ["crates/nts"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 resolver = "2"
 members = ["crates/nts", "crates/nts_set_pwd"]
-default-members = ["crates/nts"]
+# default-members = ["crates/nts"]

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,12 @@
         };
 
         packages.nts = naersk'.buildPackage {
+          pname = "nts";
+          src = ./.;
+        };
+
+        packages.nts_set_pwd = naersk'.buildPackage {
+          pname = "nts_set_pwd";
           src = ./.;
         };
 


### PR DESCRIPTION
This adds an output `packages.nts_set_pwd` to `flake.nix` to build `nts_set_pwd`.
Naersk seemed to have issues compiling the correct package when `default-members` was set in `Cargo.toml`, which is why this removes that option.